### PR TITLE
Version Ubuntu mis a jour

### DIFF
--- a/exercice3.tf
+++ b/exercice3.tf
@@ -29,7 +29,7 @@ resource "google_compute_instance" "instance2" {
 
   boot_disk {
     initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-1910"
+      image = "ubuntu-os-cloud/ubuntu-2010"
     }
   }
 


### PR DESCRIPTION
La version 19.10 de Ubuntu n'est plus disponible.  La version la plus proche est 20.10